### PR TITLE
:herb: Ignore `wrapper` and `index.ts`

### DIFF
--- a/.fernignore
+++ b/.fernignore
@@ -1,6 +1,6 @@
 README.md
 LICENSE
 
-wrapper/
+src/wrapper/
 test/
-index.ts
+src/index.ts


### PR DESCRIPTION
In this PR, the `.fernignore` is updated to appropriately ignore the wrapper and index.ts. Those paths need to be prepended with `src`.